### PR TITLE
Support :blur :grayscale :brighten :invert in v-image

### DIFF
--- a/soft-skia-wasm/src/lib.rs
+++ b/soft-skia-wasm/src/lib.rs
@@ -93,9 +93,9 @@ pub struct WASMImageAttr {
     width: u32,
     height: u32,
     blur: Option<f32>,
-    pub grayscale: Option<bool>,
-    pub brighten: Option<i32>,
-    pub invert: Option<bool>,
+    grayscale: Option<bool>,
+    brighten: Option<i32>,
+    invert: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/soft-skia-wasm/src/lib.rs
+++ b/soft-skia-wasm/src/lib.rs
@@ -93,6 +93,9 @@ pub struct WASMImageAttr {
     width: u32,
     height: u32,
     blur: Option<f32>,
+    pub grayscale: Option<bool>,
+    pub brighten: Option<i32>,
+    pub invert: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -387,6 +390,9 @@ impl SoftSkiaWASM {
                 width,
                 height,
                 blur,
+                grayscale,
+                brighten,
+                invert,
             }) => self.0.set_shape_to_child(
                 id,
                 Shapes::I(Image {
@@ -396,6 +402,9 @@ impl SoftSkiaWASM {
                     width,
                     height,
                     blur,
+                    grayscale,
+                    brighten,
+                    invert,
                 }),
             ),
             WASMShapesAttr::T(WASMTextAttr {

--- a/soft-skia-wasm/src/lib.rs
+++ b/soft-skia-wasm/src/lib.rs
@@ -92,6 +92,7 @@ pub struct WASMImageAttr {
     y: i32,
     width: u32,
     height: u32,
+    blur: Option<f32>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -385,6 +386,7 @@ impl SoftSkiaWASM {
                 image,
                 width,
                 height,
+                blur,
             }) => self.0.set_shape_to_child(
                 id,
                 Shapes::I(Image {
@@ -393,6 +395,7 @@ impl SoftSkiaWASM {
                     y,
                     width,
                     height,
+                    blur,
                 }),
             ),
             WASMShapesAttr::T(WASMTextAttr {

--- a/soft-skia/Cargo.toml
+++ b/soft-skia/Cargo.toml
@@ -12,6 +12,7 @@ png = "0.17.5"
 tiny-skia = "0.10.0"
 base64 = "0.21.0"
 fontdue = "0.7.3"
+image = "0.25.1"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/soft-skia/src/shape.rs
+++ b/soft-skia/src/shape.rs
@@ -115,6 +115,9 @@ pub struct Image {
     pub width: u32,
     pub height: u32,
     pub blur: Option<f32>,
+    pub grayscale: Option<bool>,
+    pub brighten: Option<i32>,
+    pub invert: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -511,13 +514,28 @@ impl Shape for Image {
     }
 
     fn draw(&self, pixmap: &mut Pixmap, context: &DrawContext) -> () {
-        let mut u8_array = base64::decode(&self.image).expect("base64 decode failed");
+        let u8_array = base64::decode(&self.image).expect("base64 decode failed");
         let mut bytes: Vec<u8> = Vec::new();
 
         let mut img = ImageReader::new(Cursor::new(&u8_array as &[u8])).with_guessed_format().unwrap().decode().unwrap();
+
         if let Some(blur) = self.blur {
             img = img.blur(blur);
         }
+        if let Some(grayscale) = self.grayscale {
+            if grayscale {
+                img = img.grayscale();
+            }
+        }
+        if let Some(brighten) = self.brighten {
+            img = img.brighten(brighten);
+        }
+        if let Some(invert) = self.invert {
+            if invert {
+                img.invert();
+            }
+        }
+
         img.write_to(&mut Cursor::new(&mut bytes), image::ImageFormat::Png).unwrap();
 
         let p = Pixmap::decode_png(&bytes).expect("decode png failed");

--- a/vue-playground/src/App.vue
+++ b/vue-playground/src/App.vue
@@ -74,6 +74,14 @@
         >
         </v-rect>
         <v-image
+          :x="30"
+          :y="40"
+          :image="'https://raw.githubusercontent.com/rustq/vue-skia/main/vue-playground/src/assets/logo.png'"
+          :width="70"
+          :height="70"
+          v-bind:blur="10"
+        ></v-image>
+        <v-image
           :x="0"
           :y="0"
           :image="'https://raw.githubusercontent.com/rustq/vue-skia/main/vue-playground/src/assets/logo.png'"

--- a/vue-playground/src/App.vue
+++ b/vue-playground/src/App.vue
@@ -80,6 +80,9 @@
           :width="70"
           :height="70"
           v-bind:blur="10"
+          :grayscale="false"
+          :brighten="40"
+          :invert="false"
         ></v-image>
         <v-image
           :x="0"

--- a/vue-playground/src/code.ts
+++ b/vue-playground/src/code.ts
@@ -16,6 +16,14 @@ export default `<v-surface :width="360" :height="360">
     [138, 10],
   ]" :style="'fill'" :strokeWidth="1" :color="'rgba(200, 255, 0, 0.7)'" />
   <v-image
+    :x="30"
+    :y="40"
+    :image="'https://raw.githubusercontent.com/rustq/vue-skia/main/vue-playground/src/assets/logo.png'"
+    :width="70"
+    :height="70"
+    v-bind:blur="10"
+  ></v-image>
+  <v-image
     :x="0"
     :y="0"
     :image="'https://raw.githubusercontent.com/rustq/vue-skia/main/vue-playground/src/assets/logo.png'"

--- a/vue-playground/src/code.ts
+++ b/vue-playground/src/code.ts
@@ -22,6 +22,9 @@ export default `<v-surface :width="360" :height="360">
     :width="70"
     :height="70"
     v-bind:blur="10"
+    :grayscale="false"
+    :brighten="40"
+    :invert="false"
   ></v-image>
   <v-image
     :x="0"

--- a/vue-skia-framework/components/VImage.vue
+++ b/vue-skia-framework/components/VImage.vue
@@ -34,6 +34,10 @@ export default defineComponent({
     height: {
       type: Number as PropType<number>,
       required: true,
+    },
+    filter: {
+      type: Number as PropType<number>,
+      required: false,
     }
   },
   methods: {

--- a/vue-skia-framework/components/VImage.vue
+++ b/vue-skia-framework/components/VImage.vue
@@ -35,8 +35,20 @@ export default defineComponent({
       type: Number as PropType<number>,
       required: true,
     },
-    filter: {
+    blur: {
       type: Number as PropType<number>,
+      required: false,
+    },
+    grayscale: {
+      type: Boolean as PropType<boolean>,
+      required: false,
+    },
+    brighten: {
+      type: Number as PropType<number>,
+      required: false,
+    },
+    invert: {
+      type: Boolean as PropType<boolean>,
       required: false,
     }
   },

--- a/vue-skia-framework/plugin/index.ts
+++ b/vue-skia-framework/plugin/index.ts
@@ -170,6 +170,7 @@ const VSKNode = (name: string) => {
                         y: attrs.y,
                         width: attrs.width,
                         height: attrs.height,
+                        blur: attrs.blur,
                       },
                     },
                   });

--- a/vue-skia-framework/plugin/index.ts
+++ b/vue-skia-framework/plugin/index.ts
@@ -171,6 +171,9 @@ const VSKNode = (name: string) => {
                         width: attrs.width,
                         height: attrs.height,
                         blur: attrs.blur,
+                        grayscale: attrs.grayscale,
+                        brighten: attrs.brighten,
+                        invert: attrs.invert,
                       },
                     },
                   });


### PR DESCRIPTION
Support `:blur` `:grayscale` `:brighten` `:invert` in `v-image`

[https://661ffed7fab17a73c76391be--vue-skia.netlify.app/](https://661ffed7fab17a73c76391be--vue-skia.netlify.app/)

<img width="703" alt="截屏2024-04-18 00 57 40" src="https://github.com/rustq/vue-skia/assets/11075892/f9ab024d-fc06-4262-9b33-8023735fef06">

